### PR TITLE
[40] 인증 구현

### DIFF
--- a/src/api/routes/auth.js
+++ b/src/api/routes/auth.js
@@ -1,8 +1,10 @@
 const express = require("express");
 const router = express.Router();
 
+const authController = require("./controllers/auth.controller");
 const loginController = require("./controllers/login.controller");
 
+router.get("/", authController.authenticateUser);
 router.post("/login", loginController.login);
 router.post("/refresh", loginController.refreshLogin);
 

--- a/src/api/routes/controllers/auth.controller.js
+++ b/src/api/routes/controllers/auth.controller.js
@@ -1,0 +1,27 @@
+const utils = require("../../../utils");
+
+exports.authenticateUser = async (req, res, next) => {
+  try {
+    const accessToken = req.headers.authorization;
+
+    if (!accessToken) {
+      return res.json({
+        isSuccess: false,
+      });
+    }
+
+    const decode = utils.authenticateToken(accessToken);
+
+    if (!decode) {
+      return res.json({
+        isSuccess: false,
+      });
+    }
+
+    res.json({
+      isSuccess: true,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/api/routes/controllers/auth.controller.js
+++ b/src/api/routes/controllers/auth.controller.js
@@ -1,27 +1,23 @@
 const utils = require("../../../utils");
 
 exports.authenticateUser = async (req, res, next) => {
-  try {
-    const accessToken = req.headers.authorization;
+  const accessToken = req.headers.authorization;
 
-    if (!accessToken) {
-      return res.json({
-        isSuccess: false,
-      });
-    }
-
-    const decode = utils.authenticateToken(accessToken);
-
-    if (!decode) {
-      return res.json({
-        isSuccess: false,
-      });
-    }
-
-    res.json({
-      isSuccess: true,
+  if (!accessToken) {
+    return res.json({
+      isSuccess: false,
     });
-  } catch (error) {
-    next(error);
   }
+
+  const decode = utils.authenticateToken(accessToken);
+
+  if (!decode) {
+    return res.json({
+      isSuccess: false,
+    });
+  }
+
+  res.json({
+    isSuccess: true,
+  });
 };

--- a/src/api/routes/controllers/login.controller.js
+++ b/src/api/routes/controllers/login.controller.js
@@ -12,7 +12,7 @@ exports.login = async (req, res, next) => {
       });
     }
 
-    const { email, nickName, profile } = user;
+    const { email, displayName, profile } = user;
     const { newAccessToken, newRefreshToken } = utils.createToken(email);
 
     loginService.saveToken(email, newRefreshToken);
@@ -20,7 +20,7 @@ exports.login = async (req, res, next) => {
 
     return res.json({
       email,
-      nickName,
+      displayName,
       profile,
       newAccessToken,
       isSuccess: true,

--- a/src/api/routes/controllers/login.controller.js
+++ b/src/api/routes/controllers/login.controller.js
@@ -3,24 +3,27 @@ const utils = require("../../../utils");
 
 exports.login = async (req, res, next) => {
   try {
-    const { email } = req.body;
-    const user = await loginService.checkUser(email);
+    const requestEmail = req.body.email;
+    const user = await loginService.checkUser(requestEmail);
 
-    if (user) {
-      const { newAccessToken, newRefreshToken } = utils.makeToken(email);
-
-      loginService.saveToken(email, newRefreshToken);
-      res.cookie("refreshToken", newRefreshToken, { httpOnly: true });
-
+    if (!user) {
       return res.json({
-        user,
-        newAccessToken,
-        isSuccess: true,
+        isSuccess: false,
       });
     }
 
+    const { email, nickName, profile } = user;
+    const { newAccessToken, newRefreshToken } = utils.createToken(email);
+
+    loginService.saveToken(email, newRefreshToken);
+    res.cookie("refreshToken", newRefreshToken, { httpOnly: true });
+
     return res.json({
-      isSuccess: false,
+      email,
+      nickName,
+      profile,
+      newAccessToken,
+      isSuccess: true,
     });
   } catch (error) {
     next(error);
@@ -53,7 +56,7 @@ exports.refreshLogin = async (req, res, next) => {
       });
     }
 
-    const { newAccessToken, newRefreshToken } = utils.makeToken(decodedEmail);
+    const { newAccessToken, newRefreshToken } = utils.createToken(decodedEmail);
     loginService.saveToken(decodedEmail, newRefreshToken);
     res.cookie("refreshToken", newRefreshToken, { httpOnly: true });
 

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -6,12 +6,13 @@ const UserSchema = new Schema({
   email: {
     type: String,
     unique: true,
+    required: true,
     validate: {
       validator: isEmail,
       message: "이메일 형식이 틀렸습니다.",
     },
   },
-  nickName: String,
+  displayName: String,
   profile: {
     type: String,
     validate: {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 const jwt = require("jsonwebtoken");
 
-exports.makeToken = payload => {
+exports.createToken = payload => {
   const newAccessToken = jwt.sign(
     {
       payload,


### PR DESCRIPTION
# [40] {인증구현}
## 노션 칸반 링크
- [인증 구현](https://www.notion.so/vanillacoding/Task-097f85cb828f42519076f255cc64bbb0)

## 카드에서 구현 혹은 해결하려는 내용
- login 후 받은 accessToken을 프론트에서 axios header에 default로 넣어줌. 그후 인증 필요한 페이지에서 서버에서 req.headers에서 accessToken을 받아와서, decode 해주는 함수 구현
- 처음에는 서버 미들웨어로 작성예정이었지만, 그럴 경우 decode결과가 안좋았을 때, next(error)로 밖에 못해줌
- 따라서 endpoint를 따로 설정한 후, 프론트 단에서 인증이 필요할 때, 해당 api를 사용할 수 있도록 (hoc 사용 예정) 할 예정

## 테스트 방법
- PostMan Get:http://localhost:8000/api/auth/
Headers에 Key값 Authorization 넣어준 후 value에 로그인에서 받은 accessToken 기입. => "isSuccess": true
value값 다르면 => "isSuccess": false

## 기타 사항
- 그 외 코드 내용에서 읽는 사람이 이해하기 어렵거나, 이렇게 구현하는게 맞는지 고민되는 부분이 있으면 코멘트 달기
- 그 외 코드 내용에서 리뷰어가 이해하기 어렵거나, 이렇게 구현하는게 맞는지 고민되는 부분이 있으면 코멘트 달기
    - 예: (이 부분은 이러이러하게 고민하다가 이렇게 결정했는데 혹시 ~님(리뷰어)은 어떻게 생각하시나요?)
    - 예: (이 부분은 이러이러한 배경 때문에 가독성이 떨어지지만 이렇게 짜게 됐습니다.)
