### PR TITLE
[24] 특정 최종목표 가져오기

### DIFF
--- a/src/api/middlewares/validator.js
+++ b/src/api/middlewares/validator.js
@@ -1,0 +1,16 @@
+const mongoose = require("mongoose");
+
+const verifyParams = (req, res, next) => {
+  const { id } = req.params;
+
+  if (!mongoose.isValidObjectId(id)) {
+    return res.json({
+      code: 400,
+      message: "Invalid Goal Id",
+    });
+  }
+
+  next();
+};
+
+exports.verifyParams = verifyParams;

--- a/src/api/middlewares/validator.js
+++ b/src/api/middlewares/validator.js
@@ -6,7 +6,7 @@ const verifyParams = (req, res, next) => {
   if (!mongoose.isValidObjectId(id)) {
     return res.json({
       code: 400,
-      message: "Invalid Goal Id",
+      message: "Invalid Id",
     });
   }
 

--- a/src/api/routes/controllers/goals.controller.js
+++ b/src/api/routes/controllers/goals.controller.js
@@ -1,0 +1,30 @@
+const goalsService = require("../../services/goals.service");
+
+exports.getOne = async (req, res, next) => {
+  const { id } = req.params;
+  const result = await goalsService.getDetail(id);
+
+  if (!result || result.error) {
+    return res.json({
+      result: "error",
+      error: {
+        message: "Invalid Goal Id",
+        code: 400,
+      },
+    });
+  }
+
+  const { title, subGoals, level, users, messages } = result;
+
+  res.json({
+    result: {
+      mainGoal: {
+        title,
+        subGoals,
+        level,
+        users,
+        messages,
+      },
+    },
+  });
+};

--- a/src/api/routes/controllers/goals.controller.js
+++ b/src/api/routes/controllers/goals.controller.js
@@ -4,14 +4,18 @@ exports.getOne = async (req, res, next) => {
   const { id } = req.params;
   const result = await goalsService.getDetail(id);
 
-  if (!result || result.error) {
+  if (!result) {
     return res.json({
       result: "error",
       error: {
-        message: "Invalid Goal Id",
-        code: 400,
+        message: "Not Found",
+        code: 404,
       },
     });
+  }
+
+  if (result.error) {
+    return next(result.error);
   }
 
   const { title, subGoals, level, users, messages } = result;

--- a/src/api/routes/goals.js
+++ b/src/api/routes/goals.js
@@ -1,7 +1,11 @@
 const express = require("express");
-
 const router = express.Router();
 
+const { verifyParams } = require("../middlewares/validator");
+const goalsController = require("./controllers/goals.controller");
+
 router.get("/", (req, res, next) => {});
+// verifyToken 필요
+router.get("/mainGoal/:id", verifyParams, goalsController.getOne);
 
 module.exports = router;

--- a/src/api/services/goals.service.js
+++ b/src/api/services/goals.service.js
@@ -1,0 +1,16 @@
+const MainGoal = require("../../models/MainGoal");
+
+exports.getDetail = async id => {
+  try {
+    const result = await MainGoal.findById(id);
+    return result;
+  } catch (error) {
+    return {
+      result: "error",
+      error: {
+        message: "Internal Error",
+        code: 500,
+      },
+    };
+  }
+};

--- a/src/api/services/goals.service.js
+++ b/src/api/services/goals.service.js
@@ -2,7 +2,7 @@ const MainGoal = require("../../models/MainGoal");
 
 exports.getDetail = async id => {
   try {
-    const result = await MainGoal.findById(id);
+    const result = await MainGoal.findById(id).lean();
     return result;
   } catch (error) {
     return {


### PR DESCRIPTION
# [24] 특정 최종목표 가져오기

## 노션 칸반 링크

- [[Task] Get - 특정 최종목표 가져오기](https://www.notion.so/vanillacoding/Task-Get-a03c3460516d457aac0831f50edccd28)

## 카드에서 구현 혹은 해결하려는 내용
- Feat: 특정 최종목표(mainGoal) 상세내용 GET API
- Feat: req.params id validator 추가
- Feat: 서비스 로직 추가

## 테스트 방법
- 테스트용 user 데이터로 임시 테스트, email 및 profile을 기획했던 형태로 response 보내는 데 성공
- GET, ~/api/goals/mainGoal/:id
- res
```
{
    result: {
      mainGoal: {
        title,
        subGoals,
        level,
        users,
        messages,
      },
    },
  }
```

## 기타 사항
- populate 없이 response를 내보내는 방향으로 코드 작성하였습니다. subGoals 등은 [string1, string 2, ...] 형태로 나갈 것으로 예상됩니다. populate 필요한 경우 수정해야 합니다.
- mainGoal POST API와 함께 테스트가 필요합니다.
- accessToken을 verify 할 수 있는 미들웨어가 필요합니다.

## 추가 수정내역
- validator 메시지 수정("Invalid Id")
- 컨트롤러 error 처리 분기 404(validator는 통과했으나 검색 결과가 null인 경우)/500으로 분리
- 서비스 로직에 lean() 메서드 적용