### PR TITLE
[36] POST 캘린더 todo memo 저장

### DIFF
--- a/src/api/middlewares/validator.js
+++ b/src/api/middlewares/validator.js
@@ -23,6 +23,8 @@ const repetitoinSchema = Joi.object({
   week: Joi.number().min(1).max(3).required(),
 }).required();
 
+const todoMemoSchema = Joi.string().max(200).required();
+
 exports.verifyParams = verifyParams;
 
 exports.verifyDateRepetitoin = async (req, res, next) => {
@@ -31,6 +33,19 @@ exports.verifyDateRepetitoin = async (req, res, next) => {
 
     await dateValidation.validateAsync(date);
     await repetitoinSchema.validateAsync(repetition);
+    next();
+  } catch (error) {
+    error.status = 400;
+    next(error);
+  }
+};
+
+exports.verifyTodoMemo = async (req, res, next) => {
+  try {
+    const { memo, date } = req.body;
+
+    await dateValidation.validateAsync(date);
+    await todoMemoSchema.validateAsync(memo);
     next();
   } catch (error) {
     error.status = 400;

--- a/src/api/routes/controllers/auth.controller.js
+++ b/src/api/routes/controllers/auth.controller.js
@@ -1,5 +1,5 @@
-const authService = require("../../services/auth.service");
 const utils = require("../../../utils");
+const authService = require("../../services/auth.service");
 
 exports.logout = async (req, res, next) => {
   try {
@@ -54,6 +54,7 @@ exports.refreshLogin = async (req, res, next) => {
         isSuccess: false,
       });
     }
+
     const decodedEmail = await utils.decodeToken(refreshToken);
     const user = await authService.checkUser(decodedEmail);
 

--- a/src/api/routes/controllers/todos.controller.js
+++ b/src/api/routes/controllers/todos.controller.js
@@ -21,7 +21,30 @@ exports.addTodo = async (req, res, next) => {
       });
     }
 
-    return res.json({
+    res.json({
+      result: "ok",
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.saveTodoMemo = async (req, res, next) => {
+  const { date, memo } = req.body;
+  const { id } = req.params;
+
+  try {
+    const result = await todosService.saveTodoMemo(id, date, memo);
+
+    if (!result) {
+      res.status(404);
+      return res.json({
+        result: "error",
+        message: "Not Found",
+      });
+    }
+
+    res.json({
       result: "ok",
     });
   } catch (error) {

--- a/src/api/routes/todos.js
+++ b/src/api/routes/todos.js
@@ -1,11 +1,12 @@
 const express = require("express");
 const router = express.Router();
 
-const todosController = require("./controllers/todos.controller");
 const auth = require("../middlewares/auth");
+const todosController = require("./controllers/todos.controller");
 const {
   verifyParams,
   verifyDateRepetitoin,
+  verifyTodoMemo,
 } = require("../middlewares/validator");
 
 router.post(
@@ -14,6 +15,14 @@ router.post(
   verifyParams,
   verifyDateRepetitoin,
   todosController.addTodo,
+);
+
+router.post(
+  "/memo/:id",
+  // auth.authenticateUser,
+  verifyParams,
+  verifyTodoMemo,
+  todosController.saveTodoMemo,
 );
 
 module.exports = router;

--- a/src/api/routes/users.js
+++ b/src/api/routes/users.js
@@ -1,8 +1,8 @@
 const express = require("express");
 const router = express.Router();
 
-const usersController = require("./controllers/users.controller");
 const auth = require("../middlewares/auth");
+const usersController = require("./controllers/users.controller");
 
 router.get("/", (req, res, next) => {});
 router.post("/", usersController.create);

--- a/src/api/services/goals.service.js
+++ b/src/api/services/goals.service.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+
 const MainGoal = require("../../models/MainGoal");
 const User = require("../../models/User");
 const Todo = require("../../models/Todo");

--- a/src/api/services/todos.service.js
+++ b/src/api/services/todos.service.js
@@ -1,4 +1,5 @@
 const { add, format } = require("date-fns");
+
 const Todo = require("../../models/Todo");
 
 exports.addDateToTodo = async (id, date) => {
@@ -25,10 +26,12 @@ exports.repeatTodo = async (id, date, type, week) => {
           "yyyy-MM-dd",
         );
         const result = await exports.addDateToTodo(id, currentDate);
+
         if (!result.isSuccess) {
           return result;
         }
       }
+
       break;
 
     case "EVERY_WEEK":
@@ -38,12 +41,21 @@ exports.repeatTodo = async (id, date, type, week) => {
           "yyyy-MM-dd",
         );
         const result = await exports.addDateToTodo(id, currentDate);
+
         if (!result.isSuccess) {
           return result;
         }
       }
+
       break;
   }
 
   return { isSuccess: true };
+};
+
+exports.saveTodoMemo = async (id, date, memo) => {
+  const todo = await Todo.findById(id);
+
+  todo.addedInCalendar.set(date, { memo });
+  return await todo.save();
 };

--- a/src/api/services/users.service.js
+++ b/src/api/services/users.service.js
@@ -1,6 +1,7 @@
+const { add, format } = require("date-fns");
+
 const User = require("../../models/User");
 const MainGoal = require("../../models/MainGoal");
-const { add, format } = require("date-fns");
 
 exports.signup = async userData => {
   const { email, displayName, profile } = userData;
@@ -43,10 +44,10 @@ exports.getTodosFromIds = async (id, date, days) => {
 
   for (let i = 0; i <= days; i++) {
     const currentDate = format(add(date, { days: i }), "yyyy-MM-dd");
-
     const todosInDate = createdTodos.filter(todo => {
       return todo.addedInCalendar.has(currentDate);
     });
+
     if (todosInDate.length === 0) {
       continue;
     }


### PR DESCRIPTION
- Feat: calendar todo memo save 구현

# [36] POST - 캘린더에서 Todo 메모
## 노션 칸반 링크

- [POST - 캘린더에서 Todo 메모](https://www.notion.so/vanillacoding/Task-POST-Todo-fa98d29348ee4f4da7ddd02e55a2ab69)

## 카드에서 구현 혹은 해결하려는 내용
- Feat: calendar 내에서 memo 값을 저장할 시 db에 저장 

## 테스트 방법
- postman: todoId의 addedInCalendar값이 수정한 값으로 저장되는지 테스트

