### PR TITLE
[51] GET - MainGoal 세부정보 API 수정

### DIFF
--- a/src/api/services/goals.service.js
+++ b/src/api/services/goals.service.js
@@ -4,7 +4,9 @@ const User = require("../../models/User");
 const Todo = require("../../models/Todo");
 
 exports.getDetail = async id => {
-  const result = await MainGoal.findById(id).lean();
+  const result = await MainGoal.findById(id)
+    .lean()
+    .populate("subGoals.todos", "title");
   return result;
 };
 


### PR DESCRIPTION
# [51] GET - MainGoal 세부정보 API 수정

## 노션 칸반 링크

- [[51] GET - MainGoal 세부정보 API 수정](https://www.notion.so/vanillacoding/Task-GET-MainGoal-fab2a338126d43d1bdc4b875d1e982d4)

## 카드에서 구현 혹은 해결하려는 내용

- Feat: todos populate 추가

## 기타 사항

- 기존 MainGoal 스키마의 todos가 내장에서 참조로 변경되면서, todos populate 기능 추가함
