### PR TITLE
[31] Backend 팀 프로젝트 유저 추가

### DIFF
--- a/src/api/middlewares/validator.js
+++ b/src/api/middlewares/validator.js
@@ -15,17 +15,18 @@ const verifyParams = (req, res, next) => {
   next();
 };
 
-const dateValidation = Joi.date().required();
-
-const repetitoinSchema = Joi.object({
-  isRepeat: Joi.boolean().required(),
-  type: Joi.string().default("EVERY_DAY").required(),
-  week: Joi.number().min(1).max(3).required(),
-}).required();
-
-const todoMemoSchema = Joi.string().max(200).required();
-
 exports.verifyParams = verifyParams;
+
+const dateValidation = Joi.date().required();
+const repetitoinSchema = Joi.object()
+  .keys({
+    isRepeat: Joi.boolean().required(),
+    type: Joi.string().default("EVERY_DAY").required(),
+    week: Joi.number().min(1).max(3).required(),
+  })
+  .required();
+const todoMemoSchema = Joi.string().max(200).required();
+const emailSchema = Joi.string().email().required();
 
 exports.verifyDateRepetitoin = async (req, res, next) => {
   try {
@@ -46,6 +47,18 @@ exports.verifyTodoMemo = async (req, res, next) => {
 
     await dateValidation.validateAsync(date);
     await todoMemoSchema.validateAsync(memo);
+    next();
+  } catch (error) {
+    error.status = 400;
+    next(error);
+  }
+};
+
+exports.verifyEmail = async (req, res, next) => {
+  try {
+    const { email } = req.body;
+
+    await emailSchema.validateAsync(email);
     next();
   } catch (error) {
     error.status = 400;

--- a/src/api/routes/controllers/goals.controller.js
+++ b/src/api/routes/controllers/goals.controller.js
@@ -123,3 +123,25 @@ exports.modifySubGoal = async (req, res, next) => {
     next(error);
   }
 };
+
+exports.addUser = async (req, res, next) => {
+  try {
+    const goalId = req.params.id;
+    const email = req.body.email;
+    const result = await goalsService.addUser(goalId, email);
+
+    if (!result) {
+      res.status(400);
+      return res.json({
+        result: "error",
+        message: "Failed to add user",
+      });
+    }
+
+    res.json({
+      result: "ok",
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/api/routes/goals.js
+++ b/src/api/routes/goals.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router();
 
-const { verifyParams } = require("../middlewares/validator");
+const { verifyParams, verifyEmail } = require("../middlewares/validator");
 const goalsController = require("./controllers/goals.controller");
 const auth = require("../middlewares/auth");
 
@@ -24,6 +24,13 @@ router.put(
   auth.authenticateUser,
   verifyParams,
   goalsController.modifyMainGoal,
+);
+router.post(
+  "/mainGoal/:id/users",
+  auth.authenticateUser,
+  verifyParams,
+  verifyEmail,
+  goalsController.addUser,
 );
 router.put(
   "/subGoal/:id",

--- a/src/api/services/goals.service.js
+++ b/src/api/services/goals.service.js
@@ -69,3 +69,11 @@ exports.modifySubGoal = async (subGoal, subGoalId, mainGoalId) => {
 
   return await mainGoal.save();
 };
+
+exports.addUser = async (goalId, email) => {
+  const user = await User.findOne({ email }, "_id").exec();
+
+  return await MainGoal.findByIdAndUpdate(goalId, {
+    $pull: { users: user._id },
+  }).exec();
+};


### PR DESCRIPTION
# [31] Post - 팀 프로젝트 유저 추가

## 노션 칸반 링크

- [Post - 팀 프로젝트 유저 추가](https://www.notion.so/vanillacoding/Task-Post-75b9f548520743a39c30a3a508704967)

## 카드에서 구현 혹은 해결하려는 내용
- Feat: verifyEmail middleware 추가
- Feat: 팀 프로젝트 시 협업할 유저를 추가할 경우 MainGoal user의 userId 저장

## 테스트 방법
- postman: req.body 에 email 값 보낼 시 mainGoal user의 userId가 차례대로 저장되는지 확인


