### PR TITLE
[21] 공유시 이메일로 유저 확인 / [35] 특정날짜 todo 삭제 / [32] todo 추가 Fix

### DIFF
--- a/src/api/middlewares/auth.js
+++ b/src/api/middlewares/auth.js
@@ -28,7 +28,7 @@ exports.authenticateUser = async (req, res, next) => {
       });
     }
 
-    req.app.locals.user = user;
+    res.locals.user = user;
 
     next();
   } catch (error) {

--- a/src/api/routes/controllers/auth.controller.js
+++ b/src/api/routes/controllers/auth.controller.js
@@ -3,7 +3,7 @@ const authService = require("../../services/auth.service");
 
 exports.logout = async (req, res, next) => {
   try {
-    await authService.logout(req.app.locals.user);
+    await authService.logout(res.locals.user);
 
     delete req.headers.authorization;
     res.clearCookie("refreshToken");

--- a/src/api/routes/controllers/goals.controller.js
+++ b/src/api/routes/controllers/goals.controller.js
@@ -33,7 +33,7 @@ exports.getOne = async (req, res, next) => {
 
 exports.create = async (req, res, next) => {
   try {
-    const result = await goalsService.create(req.app.locals.user);
+    const result = await goalsService.create(res.locals.user);
     const mainGoalId = result;
 
     if (!result) {
@@ -57,7 +57,7 @@ exports.create = async (req, res, next) => {
 exports.delete = async (req, res, next) => {
   try {
     const goalId = req.params.id;
-    const userId = req.app.locals.userId;
+    const userId = res.locals.userId;
     const result = await goalsService.delete(goalId, userId);
 
     if (!result) {

--- a/src/api/routes/controllers/todos.controller.js
+++ b/src/api/routes/controllers/todos.controller.js
@@ -7,10 +7,15 @@ exports.addTodo = async (req, res, next) => {
     let addResult = null;
 
     if (repetition.isRepeat) {
-      const { type, week } = repetition;
-      addResult = await todosService.repeatTodo(id, date, type, week);
+      const { type, duration } = repetition;
+      addResult = await todosService.repeatTodo(
+        id,
+        new Date(date),
+        type,
+        duration,
+      );
     } else {
-      addResult = await todosService.addDateToTodo(id, date);
+      addResult = await todosService.addDateToTodo(id, new Date(date));
     }
 
     if (!addResult.isSuccess) {
@@ -47,6 +52,17 @@ exports.saveTodoMemo = async (req, res, next) => {
     res.json({
       result: "ok",
     });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.deleteTodo = async (req, res, next) => {
+  try {
+    const todoId = req.params.id;
+    const date = req.body.date;
+
+    await todosService.deleteTodo(todoId, new Date(date));
   } catch (error) {
     next(error);
   }

--- a/src/api/routes/controllers/users.controller.js
+++ b/src/api/routes/controllers/users.controller.js
@@ -15,7 +15,7 @@ exports.create = async (req, res, next) => {
 
 exports.getGoals = async (req, res, next) => {
   try {
-    const user = req.app.locals.user;
+    const user = res.locals.user;
     const { _id } = user;
     const { createdGoals } = await User.findById(_id, "createdGoals -_id");
     const result = await usersService.getGoalsFromIds(createdGoals);
@@ -30,7 +30,7 @@ exports.getTodos = async (req, res, next) => {
   try {
     const requestDate = new Date(req.headers.currentdate);
     const days = req.headers.days;
-    const user = req.app.locals.user;
+    const user = res.locals.user;
     const { _id } = user;
     const todos = await usersService.getTodosFromIds(_id, requestDate, days);
 
@@ -38,7 +38,27 @@ exports.getTodos = async (req, res, next) => {
       result: todos,
     });
   } catch (error) {
-    console.log(error);
+    next(error);
+  }
+};
+
+exports.findUserByEmail = async (req, res, next) => {
+  try {
+    const user = await usersService.findUser(req.headers.otheruser);
+
+    if (!user) {
+      res.status(400);
+      return res.json({
+        result: "false",
+        message: "해당하는 유저가 없습니다.",
+      });
+    }
+
+    res.json({
+      result: "ok",
+      user,
+    });
+  } catch (error) {
     next(error);
   }
 };

--- a/src/api/routes/todos.js
+++ b/src/api/routes/todos.js
@@ -11,7 +11,7 @@ const {
 
 router.post(
   "/:id",
-  // auth.authenticateUser,
+  auth.authenticateUser,
   verifyParams,
   verifyDateRepetition,
   todosController.addTodo,
@@ -23,6 +23,13 @@ router.post(
   verifyParams,
   verifyTodoMemo,
   todosController.saveTodoMemo,
+);
+
+router.delete(
+  "/:id",
+  auth.authenticateUser,
+  verifyParams,
+  todosController.deleteTodo,
 );
 
 module.exports = router;

--- a/src/api/routes/users.js
+++ b/src/api/routes/users.js
@@ -1,10 +1,9 @@
 const express = require("express");
 const router = express.Router();
-
-const auth = require("../middlewares/auth");
 const usersController = require("./controllers/users.controller");
+const auth = require("../middlewares/auth");
 
-router.get("/", (req, res, next) => {});
+router.get("/", auth.authenticateUser, usersController.findUserByEmail);
 router.post("/", usersController.create);
 router.get("/goals", auth.authenticateUser, usersController.getGoals);
 router.get("/todos", auth.authenticateUser, usersController.getTodos);

--- a/src/app.js
+++ b/src/app.js
@@ -35,7 +35,7 @@ app.use((req, res, next) => {
 app.use((err, req, res, next) => {
   // set locals, only providing error in development
   res.locals.message = err.message;
-  res.locals.error = req.app.get("env") === "development" ? err : {};
+  res.locals.error = res.app.get("env") === "development" ? err : {};
 
   // render the error page
   res.status(err.status || 500);


### PR DESCRIPTION
# [21] 공유시 이메일로 확인 / [35] 특정날짜 todo 삭제 / 

## 노션 칸반 링크

- [[Task] Get - 공유 시 유저정보 가져오기](https://www.notion.so/vanillacoding/Task-Get-e6c7e250631f41238dfc4bbd6f7f53f4)
- [[Task] Delete 캘린더에서 Todo삭제](https://www.notion.so/vanillacoding/Task-Delete-Todo-b4382057e91b4f799131649fdbc86905)

## 카드에서 구현 혹은 해결하려는 내용
- Feat: 공유할 때, 이메일 검색 시 활용.
- 정확히 찾으면 ok, 정확하지 않으면 false를 주어 client에서 표시할 내용을 분기처리 예정

- Feat: 특정날짜 todo 삭제
- 달력에서 모달 클릭 후 삭제 시 구동.

## 테스트 방법
-[21] 이메일로 유저확인
![image](https://user-images.githubusercontent.com/79738187/153581577-7343384e-d185-481f-973a-c7b95486c103.png)

![image](https://user-images.githubusercontent.com/79738187/153581605-a8b91585-cacd-4654-9f91-65072b513ed7.png)

-[35] 특정날자 todo 삭제
![image](https://user-images.githubusercontent.com/79738187/153581508-9d0779a0-eb87-4800-8ad0-eebda416117f.png)

![image](https://user-images.githubusercontent.com/79738187/153582347-976747b4-af17-419b-a4d3-6cb8ed9fb431.png)

![image](https://user-images.githubusercontent.com/79738187/153581420-6306e4dc-fe49-447f-845f-9ab540300053.png)

-
## 기타 사항
- todo 날짜처리 관련, 프론트에서 Date객체로 넘겨줘도, JSON이 string으로 변환하여 넘겨줌.
- 때문에, 백엔드 단에서 new Date()로 변환 하고 다시 datefns를 사용하여 저장해주고 있음. 
- 이부분 수정이 필요할듯 (todo에 저장하는 형식을 바꾸거나, 프론트에서 보내는 형식을 변화하거나 등등)
- 지난번 테스트에서는 postman으로 하여 캐치하지 못한 부분을 프론트와 연결하면서 에러 확인.

- 프론트에서 axios delete 할 때, body가 나타나게 하려면, date키를 줘서 보내줘야함. 백엔드 단에서는 이것을 body로 인식.
-[Axios Delete request with body and headers?](https://stackoverflow.com/questions/51069552/axios-delete-request-with-body-and-headers)

- req.app.locals => res.app.locals 로 변경 완료.
- 확인 시, 현재는 인증과정에서 user를 찾아 lean() 처리를 해줌.
- 이 때문에, res.app.locals로 받은 user를 바로 db수정 후 save()하기는 어려워보임.
- 혹은 lean대신 exec()를 하여, 무거운 query를 갖게하는 방안도 있음.
- 향후 논의 필요