### PR TITLE
[55] MainGoal 삭제 API 수정

### DIFF
--- a/src/api/routes/controllers/goals.controller.js
+++ b/src/api/routes/controllers/goals.controller.js
@@ -62,8 +62,8 @@ exports.create = async (req, res, next) => {
 exports.delete = async (req, res, next) => {
   try {
     const goalId = req.params.id;
-    const userId = res.locals.userId;
-    const result = await goalsService.delete(goalId, userId);
+    const { _id: userId } = res.locals.user;
+    const result = await goalsService.getSharedUsers(goalId);
 
     if (!result) {
       res.status(404);
@@ -71,6 +71,12 @@ exports.delete = async (req, res, next) => {
         result: "error",
         message: "Not Found",
       });
+    }
+
+    if (userId.toString() === result.createdBy.toString()) {
+      await goalsService.deleteAll(goalId, result.users);
+    } else {
+      await goalsService.deleteShared(goalId, userId);
     }
 
     res.json({

--- a/src/api/services/users.service.js
+++ b/src/api/services/users.service.js
@@ -36,9 +36,10 @@ exports.getGoalsFromIds = async ids => {
 
 exports.getTodosFromIds = async (id, date, days) => {
   const todos = {};
-  const { createdTodos } = await User.findById(id, "createdTodos -_id")
-    .populate("createdTodos")
-    .exec();
+  const { createdTodos } = await User.findById(
+    id,
+    "createdTodos -_id",
+  ).populate("createdTodos");
 
   for (let i = 0; i < days; i++) {
     const currentDate = format(add(date, { days: i }), "yyyy-MM-dd");
@@ -62,7 +63,7 @@ exports.getTodosFromIds = async (id, date, days) => {
 
     todos[currentDate] = revisedTodosInDate;
   }
-  console.log(todos);
+
   return todos;
 };
 


### PR DESCRIPTION

# [55] MainGoal 삭제 API 수정

## 노션 칸반 링크

- [[Task] 추가 - 메인 골 삭제 시 공유 유저의 골에서도 삭제](https://www.notion.so/vanillacoding/Task-452f25c22c144061b1f4332e93d61b02)

## 카드에서 구현 혹은 해결하려는 내용

- Feat: 삭제 API 분기 처리 추가
- MainGoal 생성자가 삭제요청 시, 만다라트 삭제 및 협업 유저의 createdGoals에서도 데이터 삭제
- 협업 유저가 삭제요청 시, 협업 유저의 createdGoals 데이터 및 MainGoal의 협업 유저 목록에서 요청 유저만 삭제
- MainGoal 도큐먼트 삭제 시 MainGoal 관련 Todo 도큐먼트 함께 삭제
