### PR TITLE
[58] 투두 체크 여부 저장

### DIFF
--- a/src/api/routes/controllers/todos.controller.js
+++ b/src/api/routes/controllers/todos.controller.js
@@ -8,6 +8,7 @@ exports.addTodo = async (req, res, next) => {
 
     if (repetition.isRepeat) {
       const { type, duration } = repetition;
+
       addResult = await todosService.repeatTodo(
         id,
         new Date(date),
@@ -57,12 +58,43 @@ exports.saveTodoMemo = async (req, res, next) => {
   }
 };
 
-exports.deleteTodo = async (req, res, next) => {
+exports.deleteCalendarTodo = async (req, res, next) => {
   try {
-    const todoId = req.params.id;
-    const date = req.body.date;
+    const { id } = req.params;
+    const { date } = req.body;
 
-    await todosService.deleteTodo(todoId, new Date(date));
+    await todosService.deleteCalendarTodo(id, new Date(date));
+
+    res.json({
+      result: "ok",
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+exports.modifyTodoCheckButton = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const { isComplete, date } = req.body;
+
+    const result = await todosService.modifyTodoCheckButton(
+      id,
+      isComplete,
+      date,
+    );
+
+    if (!result.isSuccess) {
+      res.status(404);
+      return res.json({
+        result: "error",
+        message: "존재하지 않는 Todo 입니다",
+      });
+    }
+
+    res.json({
+      result: "ok",
+    });
   } catch (error) {
     next(error);
   }

--- a/src/api/routes/controllers/users.controller.js
+++ b/src/api/routes/controllers/users.controller.js
@@ -32,7 +32,7 @@ exports.getTodos = async (req, res, next) => {
     const days = req.headers.days;
     const user = res.locals.user;
     const { _id } = user;
-    const todos = await usersService.getTodosFromIds(_id, requestDate, days);
+    const todos = await usersService.getTodosFromId(_id, requestDate, days);
 
     res.json({
       result: todos,
@@ -44,7 +44,7 @@ exports.getTodos = async (req, res, next) => {
 
 exports.findUserByEmail = async (req, res, next) => {
   try {
-    const user = await usersService.findUser(req.headers.otheruser);
+    const user = await usersService.findUserByEmail(req.headers.otheruser);
 
     if (!user) {
       res.status(400);

--- a/src/api/routes/goals.js
+++ b/src/api/routes/goals.js
@@ -2,8 +2,8 @@ const express = require("express");
 const router = express.Router();
 
 const validator = require("../middlewares/validator");
-const goalsController = require("./controllers/goals.controller");
 const auth = require("../middlewares/auth");
+const goalsController = require("./controllers/goals.controller");
 
 router.get("/", (req, res, next) => {});
 router.post("/mainGoal", auth.authenticateUser, goalsController.create);

--- a/src/api/routes/todos.js
+++ b/src/api/routes/todos.js
@@ -1,35 +1,38 @@
 const express = require("express");
 const router = express.Router();
 
+const validator = require("../middlewares/validator");
 const auth = require("../middlewares/auth");
 const todosController = require("./controllers/todos.controller");
-const {
-  verifyParams,
-  verifyDateRepetition,
-  verifyTodoMemo,
-} = require("../middlewares/validator");
 
 router.post(
   "/:id",
   auth.authenticateUser,
-  verifyParams,
-  verifyDateRepetition,
+  validator.verifyParams,
+  validator.verifyDateRepetition,
   todosController.addTodo,
 );
 
 router.post(
   "/memo/:id",
-  // auth.authenticateUser,
-  verifyParams,
-  verifyTodoMemo,
+  auth.authenticateUser,
+  validator.verifyParams,
+  validator.verifyTodoMemo,
   todosController.saveTodoMemo,
 );
 
 router.delete(
   "/:id",
   auth.authenticateUser,
-  verifyParams,
-  todosController.deleteTodo,
+  validator.verifyParams,
+  todosController.deleteCalendarTodo,
+);
+
+router.put(
+  "/calendar/:id",
+  auth.authenticateUser,
+  validator.verifyParams,
+  todosController.modifyTodoCheckButton,
 );
 
 module.exports = router;

--- a/src/api/services/todos.service.js
+++ b/src/api/services/todos.service.js
@@ -55,10 +55,24 @@ exports.saveTodoMemo = async (id, date, memo) => {
   return await todo.save();
 };
 
-exports.deleteTodo = async (todoId, dateObject) => {
+exports.deleteCalendarTodo = async (todoId, dateObject) => {
   const todo = await Todo.findById(todoId);
 
   const date = format(dateObject, "yyyy-MM-dd");
   todo.addedInCalendar.delete(date);
   await todo.save();
+};
+
+exports.modifyTodoCheckButton = async (id, isComplete, date) => {
+  const todo = await Todo.findById(id).exec();
+
+  if (!todo || !todo.addedInCalendar.has(date)) {
+    return {
+      isSuccess: false,
+    };
+  }
+
+  todo.addedInCalendar.get(date).isComplete = isComplete;
+  await todo.save();
+  return { isSuccess: true };
 };

--- a/src/api/services/users.service.js
+++ b/src/api/services/users.service.js
@@ -34,10 +34,10 @@ exports.getGoalsFromIds = async ids => {
   }
 };
 
-exports.getTodosFromIds = async (id, date, days) => {
+exports.getTodosFromId = async (id, date, days) => {
   const todos = {};
   const { createdTodos } = await User.findById(
-    id,
+    "6205d6229f17beadd1cdec65",
     "createdTodos -_id",
   ).populate("createdTodos");
 
@@ -67,11 +67,13 @@ exports.getTodosFromIds = async (id, date, days) => {
   return todos;
 };
 
-exports.findUser = async req => {
-  const user = await User.findOne({ email: req }).lean();
+exports.findUserByEmail = async userEmail => {
+  const user = await User.findOne({ userEmail }).lean();
+
   if (!user) {
     return false;
   }
+
   const { email, displayName, profile } = user;
   return { email, displayName, profile };
 };

--- a/src/api/services/users.service.js
+++ b/src/api/services/users.service.js
@@ -37,7 +37,7 @@ exports.getGoalsFromIds = async ids => {
 exports.getTodosFromId = async (id, date, days) => {
   const todos = {};
   const { createdTodos } = await User.findById(
-    "6205d6229f17beadd1cdec65",
+    id,
     "createdTodos -_id",
   ).populate("createdTodos");
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,35 @@
+const jwt = require("jsonwebtoken");
+
+exports.createToken = payload => {
+  const newAccessToken = jwt.sign(
+    {
+      payload,
+    },
+    process.env.JWT_SECRET_KEY,
+    { expiresIn: "1h" },
+  );
+
+  const newRefreshToken = jwt.sign(
+    {
+      payload,
+    },
+    process.env.JWT_SECRET_KEY,
+    { expiresIn: "24h" },
+  );
+
+  return { newAccessToken, newRefreshToken };
+};
+
+exports.decodeToken = async token => {
+  return jwt.verify(
+    token,
+    process.env.JWT_SECRET_KEY,
+    async (error, decode) => {
+      if (error) {
+        return error;
+      }
+
+      return decode.payload;
+    },
+  );
+};


### PR DESCRIPTION
- Feat: 캘린더 투두의 체크 여부 값  저장

# [58] Put - 체크 여부 저장

## 노션 칸반 링크

- [Put - 체크 여부 저장](https://www.notion.so/vanillacoding/Task-Put-d9668bcb45c946e38145e26302be9353)

## 카드에서 구현 혹은 해결하려는 내용
- Feat: 캘린더 투두의 체크 여부 값  저장


## 테스트 방법
- postman: 수정사항 값이 todo addedInCalendar의 해당 날짜 isComplete 속성에 저장 되는지 확인

## 기타 사항
```
{
      "isComplete ": false,
      "date": "랄랄라",
}
```
-  현재 로직에서는 todo의 isComplete 만 수정해주고 싶지만, memo도 같이 수정("")이 되고 있습니다.
todo를 선언해주는 것과 같이 memo 값을 다시 추출해서 선언해주고 isComplete를 수정하는 로직에서 isComplete와 같이 memo를 다시 저장해주는 로직으로 짜보려고했는데 잘 해결되지 않아 조언을 듣고자합니다! 혹시 이 외에 하나의 속성만 수정할 수 있는 더 좋은 방법이 있을까요??
