### PR TITLE
[22] Get - 채팅정보 가져오기

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ PORT=8000
 DB_HOST=mongodb+srv://admin:1111@code-problems.ntxxu.mongodb.net/hagomanda?retryWrites=true&w=majority
 URL=http://localhost:3000
 JWT_SECRET_KEY=HAGOMANDA
+CHAT_QUERY_SECRET_KEY=PLEASEQUERY

--- a/src/api/middlewares/validator.js
+++ b/src/api/middlewares/validator.js
@@ -1,5 +1,6 @@
 const mongoose = require("mongoose");
 const Joi = require("joi");
+const jwt = require("jsonwebtoken");
 
 exports.verifyParams = (req, res, next) => {
   const { id } = req.params;
@@ -64,4 +65,32 @@ exports.verifyEmail = async (req, res, next) => {
     error.status = 400;
     next(error);
   }
+};
+
+exports.verifyChatToken = (req, res, next) => {
+  const token = req.query?.nextPageToken;
+
+  if (!token || !token.length) {
+    res.locals.startIndex = undefined;
+    return next();
+  }
+
+  const decodedToken = jwt.verify(
+    token,
+    process.env.CHAT_QUERY_SECRET_KEY,
+    (error, decode) => {
+      if (error) {
+        return error;
+      }
+
+      return decode.payload;
+    },
+  );
+
+  if (decodedToken.message) {
+    return next(new Error("Invalid Token"));
+  }
+
+  res.locals.lastIndex = decodedToken.lastIndex;
+  return;
 };

--- a/src/api/routes/chats.js
+++ b/src/api/routes/chats.js
@@ -1,6 +1,16 @@
 const express = require("express");
 const router = express.Router();
 
-router.get("/", (req, res, next) => {});
+const auth = require("../middlewares/auth");
+const validator = require("../middlewares/validator");
+const chatsController = require("./controllers/chats.controller");
+
+router.get(
+  "/:id",
+  auth.authenticateUser,
+  validator.verifyParams,
+  validator.verifyChatToken,
+  chatsController.getChat,
+);
 
 module.exports = router;

--- a/src/api/routes/controllers/chats.controller.js
+++ b/src/api/routes/controllers/chats.controller.js
@@ -1,0 +1,54 @@
+const jwt = require("jsonwebtoken");
+const chatsService = require("../../services/chats.service");
+
+exports.getChat = async (req, res, next) => {
+  const { id } = req.params;
+  const { lastIndex } = res.locals;
+  const DEFAULT_LENGTH = 30;
+
+  const getResult = (index, data) => {
+    let rangeStart, chats;
+
+    if (!index) {
+      rangeStart =
+        data.length < DEFAULT_LENGTH ? 0 : data.length - DEFAULT_LENGTH;
+      chats = data.slice(rangeStart, data.length);
+    } else {
+      rangeStart = index < DEFAULT_LENGTH ? 0 : index - DEFAULT_LENGTH;
+      chats = data.slice(rangeStart, index);
+    }
+
+    return [rangeStart, chats];
+  };
+
+  const createNewNextPageToken = rangeStart => {
+    const token =
+      rangeStart === 0
+        ? null
+        : jwt.sign(
+            { lastIndex: rangeStart },
+            process.env.CHAT_QUERY_SECRET_KEY,
+            { expiresIn: "1d" },
+          );
+    return token;
+  };
+
+  try {
+    const response = await chatsService.getChatsFromGoalId(id);
+    const [rangeStart, chats] = getResult(lastIndex, response);
+    const newNextPageToken = createNewNextPageToken(rangeStart);
+
+    res.json({
+      result: {
+        messages: chats,
+        nextPageToken: newNextPageToken,
+      },
+    });
+  } catch (error) {
+    res.status(400);
+    res.json({
+      result: "error",
+      message: "messages not found",
+    });
+  }
+};

--- a/src/api/services/chats.service.js
+++ b/src/api/services/chats.service.js
@@ -1,0 +1,7 @@
+const mongoose = require("mongoose");
+const MainGoal = require("../../models/MainGoal");
+
+exports.getChatsFromGoalId = async id => {
+  const result = await MainGoal.findById(id, "messages").lean();
+  return result.messages;
+};


### PR DESCRIPTION

# [22] Get - 채팅정보 가져오기

## 노션 칸반 링크

- [[22] Get - 채팅정보 가져오기](https://www.notion.so/vanillacoding/Task-Get-3973594d88b34f9cafc25ae6381807a2)

## 카드에서 구현 혹은 해결하려는 내용

- Feat: 채팅정보 가져오기 API
- Feat: 무한스크롤 및 다음 채팅정보 가져오기를 위한 nextPageToken
- Feat: 채팅 token validator

## 기타 사항

- API 사용을 위해서는 goalId(필수) 및 nextPageToken(선택)이 필요합니다.
- 토큰 생성은 jwt를 활용했습니다. payload를 최소한으로 넣었기 때문에, 조금 더 짧은 토큰을 쓰고 싶다는 생각이 드네요.
- 쿼리 스트링 형태로 전달되어 비교적 노출이 잘 되는 토큰이라, 회원인증을 위한 토큰 secret key와는 별도로 환경변수 지정하였습니다.
