### PR TITLE
[30] 채팅 저장

### DIFF
--- a/src/api/middlewares/validator.js
+++ b/src/api/middlewares/validator.js
@@ -1,7 +1,6 @@
 const mongoose = require("mongoose");
 const Joi = require("joi");
 const jwt = require("jsonwebtoken");
-const { string } = require("joi");
 
 exports.verifyParams = (req, res, next) => {
   const { id } = req.params;

--- a/src/api/middlewares/validator.js
+++ b/src/api/middlewares/validator.js
@@ -1,6 +1,7 @@
 const mongoose = require("mongoose");
 const Joi = require("joi");
 const jwt = require("jsonwebtoken");
+const { string } = require("joi");
 
 exports.verifyParams = (req, res, next) => {
   const { id } = req.params;
@@ -93,4 +94,17 @@ exports.verifyChatToken = (req, res, next) => {
 
   res.locals.lastIndex = decodedToken.lastIndex;
   return;
+};
+
+exports.verifyMessage = (req, res, next) => {
+  const { body } = req;
+  const schema = Joi.string().min(1).max(1000).required();
+
+  try {
+    schema.validate(body);
+    next();
+  } catch (error) {
+    error.status = 400;
+    next(error);
+  }
 };

--- a/src/api/routes/chats.js
+++ b/src/api/routes/chats.js
@@ -13,4 +13,12 @@ router.get(
   chatsController.getChat,
 );
 
+router.post(
+  "/:id",
+  auth.authenticateUser,
+  validator.verifyParams,
+  validator.verifyMessage,
+  chatsController.sendMessage,
+);
+
 module.exports = router;

--- a/src/api/routes/controllers/goals.controller.js
+++ b/src/api/routes/controllers/goals.controller.js
@@ -6,7 +6,6 @@ const {
 const goalsService = require("../../services/goals.service");
 
 exports.getOne = async (req, res, next) => {
-  req.app.io.emit("foo", "foo보낸다!");
   try {
     const { id } = req.params;
     const result = await goalsService.getDetail(id);

--- a/src/api/services/chats.service.js
+++ b/src/api/services/chats.service.js
@@ -5,3 +5,24 @@ exports.getChatsFromGoalId = async id => {
   const result = await MainGoal.findById(id, "messages").lean();
   return result.messages;
 };
+
+exports.sendMessage = async (
+  mainGoalId,
+  userId,
+  message,
+  createdAt,
+  profile,
+  displayName,
+) => {
+  return await MainGoal.findByIdAndUpdate(mainGoalId, {
+    $push: {
+      messages: {
+        userId,
+        message,
+        createdAt,
+        profile,
+        displayName,
+      },
+    },
+  });
+};

--- a/src/loader/index.js
+++ b/src/loader/index.js
@@ -7,7 +7,6 @@ const startSocket = require("./socket");
 
 function initialLoader(app) {
   startSocket(app);
-
   app.use(logger("dev"));
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));

--- a/src/loader/socket.js
+++ b/src/loader/socket.js
@@ -22,6 +22,15 @@ function startSocket(app) {
     socket.on("leaveMandal", () => {
       socket.leave(currentRoom);
     });
+
+    socket.on("joinChat", id => {
+      currentRoom = "room" + id;
+      socket.join(currentRoom);
+    });
+
+    socket.on("leaveChat", () => {
+      socket.leave(currentRoom);
+    });
   });
 }
 

--- a/src/models/MainGoal.js
+++ b/src/models/MainGoal.js
@@ -30,6 +30,14 @@ const MessagesSchema = new mongoose.Schema({
     type: Date,
     required: true,
   },
+  profile: {
+    type: String,
+    required: true,
+  },
+  displayName: {
+    type: String,
+    required: true,
+  },
 });
 
 const MainGoalSchema = new mongoose.Schema({


### PR DESCRIPTION
# [30] Post - 채팅추가

## 노션 칸반 링크

- [Post - 채팅추가](https://www.notion.so/vanillacoding/Task-Post-d991a61ed24944de99a7a93e07e4dea4)

## 카드에서 구현 혹은 해결하려는 내용
- Feat: 채팅 메세지 MainGoal의 chat에 순서대로 저장


## 테스트 방법
- postman : 프론트에서 보낸 채팅이 MainGoal Chat에 순서대로 잘 저장되는지 확인
- socket을 통해 서버에서 보낸 값을 front에서 잘 받는지 확인
<img width="503" alt="스크린샷 2022-02-15 오후 8 38 49" src="https://user-images.githubusercontent.com/81217456/154055000-6ec354bd-a028-4045-ab17-9a45527c1a69.png">

## 기타 사항
- 현재 input 값에 대한 아무런 validate를 주지 않고 있는데요! 글자 수 외에 더 추가적으로 주어야할 것이 있을까요??
- 리뷰 받은 내용을 바탕으로 validator 추가 예정입니다!
-> 글자 수 제한, type string 제한 완료!