### PR TITLE
[65] [Fix] 공유하기 쿼리 에러

### DIFF
--- a/src/api/routes/controllers/goals.controller.js
+++ b/src/api/routes/controllers/goals.controller.js
@@ -39,7 +39,8 @@ exports.getOne = async (req, res, next) => {
 
 exports.create = async (req, res, next) => {
   try {
-    const result = await goalsService.create(res.locals.user);
+    const { title } = req.body;
+    const result = await goalsService.create(res.locals.user, title);
     const mainGoalId = result;
 
     if (!result) {

--- a/src/api/services/users.service.js
+++ b/src/api/services/users.service.js
@@ -69,7 +69,7 @@ exports.getTodosFromId = async (id, date, days) => {
 };
 
 exports.findUserByEmail = async userEmail => {
-  const user = await User.findOne({ userEmail }).lean();
+  const user = await User.findOne({ email: userEmail }).lean();
 
   if (!user) {
     return false;

--- a/src/models/MainGoal.js
+++ b/src/models/MainGoal.js
@@ -44,7 +44,7 @@ const MainGoalSchema = new mongoose.Schema({
   },
   subGoals: {
     type: [SubGoalSchema],
-    default: Array.from(Array(8), element => new Object()),
+    default: Array.from(Array(8), () => new Object()),
   },
   users: {
     type: [Schema.Types.ObjectId],


### PR DESCRIPTION
# [65] [Fix] 공유하기 쿼리 에러

## 노션 칸반 링크

- [[65] [Fix] 공유하기 쿼리 에러](https://www.notion.so/vanillacoding/Fix-d29fdad68fdb4432b2d4337fafa4ffb4)

## 카드에서 구현 혹은 해결하려는 내용

- Fix: 공유하기 쿼리 에러 수정
- Fix: goals.service share 로직 내 중복 objectId 처리 로직 수정

## 기타 사항

- 공유하기 쿼리 에러를 수정하고 테스트하다 보니 오류가 발생하여 서비스 로직을 추가로 수정하였습니다.
- 기존 : user 유무 및 goal 유무, 상호 간에 중복으로 추가되지 않았는지 확인 후 저장.
- 문제 : 제대로 걸러지지 않고 중복 저장되거나, 모델 save() 실패 에러 발생.
- 해결 : user 유무 및 goal 유무 확인은 동일. 대신 중복값에 대하여 $addToSet을 활용하여 중복값이 들어가지 않도록 함. 이 경우 에러는 발생하지 않음. Set과 유사하다고 보면 됨.
